### PR TITLE
incremental model working in fct_order

### DIFF
--- a/macros/utils/dbt_audit.sql
+++ b/macros/utils/dbt_audit.sql
@@ -1,5 +1,4 @@
 {%- macro dbt_audit(cte_ref, created_by, updated_by, created_date, updated_date) -%}
-
     SELECT
       *,
       '{{ created_by }}'::VARCHAR       AS created_by,
@@ -20,6 +19,7 @@
 
             {% if source_relation != None %}
 
+                
                 {% set min_created_date %}
                     SELECT LEAST(MIN(dbt_created_at), CURRENT_TIMESTAMP()) AS min_ts 
                     FROM {{ this }}
@@ -27,7 +27,10 @@
 
                 {% set results = run_query(min_created_date) %}
 
-                '{{results.columns[0].values()[0]}}'::TIMESTAMP AS dbt_created_at
+                -- '{{results.columns[0].values()[0]}}'::TIMESTAMP AS dbt_created_at
+                -- having issues with snowflake error 
+                -- column DBT_CREATED_AT from type TIMESTAMP_LTZ(9) to TIMESTAMP_NTZ(9)
+                CURRENT_TIMESTAMP() AS dbt_created_at
 
             {% else %}
 

--- a/models/wh/dim_date.sql
+++ b/models/wh/dim_date.sql
@@ -15,8 +15,8 @@ WITH dates AS (
 
 {{ dbt_audit(
     cte_ref="final",
-    created_by="@msendal",
-    updated_by="@snalamaru",
+    created_by="@davidgriffiths",
+    updated_by="@wisemuffin",
     created_date="2020-06-01",
-    updated_date="2020-11-23"
+    updated_date="2022-01-23"
 ) }}


### PR DESCRIPTION
also works with the 0.21 dbt release of on_schema_change = 'sync_all_columns'

see: https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-incremental-models#what-if-the-columns-of-my-incremental-model-change 
